### PR TITLE
Expose whitespace preserving method of the sax function

### DIFF
--- a/src/htmgrrrl.gleam
+++ b/src/htmgrrrl.gleam
@@ -114,14 +114,6 @@ pub type Attribute {
   Attribute(uri: String, prefix: String, name: String, value: String)
 }
 
-@external(erlang, "htmgrrrl_ffi", "sax")
-pub fn base(
-  a: String,
-  b: state,
-  c: fn(state, Int, SaxEvent) -> state,
-  preserve_ws: Bool,
-) -> Result(state, Nil)
-
 /// Iterate over a stream of SAX events, calling the given function for each
 /// event.
 ///
@@ -129,16 +121,9 @@ pub fn base(
 /// and the event itself, and returns the new state. The final state is
 /// returned.
 ///
-pub fn sax(a: String, b: state, c: fn(state, Int, SaxEvent) -> state) {
-  base(a, b, c, False)
-}
-
-/// A whitespace-preserving version of the `sax` function
-///
-pub fn sax_preserve_ws(
+@external(erlang, "htmgrrrl_ffi", "sax")
+pub fn sax(
   a: String,
   b: state,
   c: fn(state, Int, SaxEvent) -> state,
-) {
-  base(a, b, c, True)
-}
+) -> Result(state, Nil)

--- a/src/htmgrrrl.gleam
+++ b/src/htmgrrrl.gleam
@@ -114,6 +114,14 @@ pub type Attribute {
   Attribute(uri: String, prefix: String, name: String, value: String)
 }
 
+@external(erlang, "htmgrrrl_ffi", "sax")
+pub fn base(
+  a: String,
+  b: state,
+  c: fn(state, Int, SaxEvent) -> state,
+  preserve_ws: Bool,
+) -> Result(state, Nil)
+
 /// Iterate over a stream of SAX events, calling the given function for each
 /// event.
 ///
@@ -121,9 +129,16 @@ pub type Attribute {
 /// and the event itself, and returns the new state. The final state is
 /// returned.
 ///
-@external(erlang, "htmgrrrl_ffi", "sax")
-pub fn sax(
+pub fn sax(a: String, b: state, c: fn(state, Int, SaxEvent) -> state) {
+  base(a, b, c, False)
+}
+
+/// A whitespace-preserving version of the `sax` function
+///
+pub fn sax_preserve_ws(
   a: String,
   b: state,
   c: fn(state, Int, SaxEvent) -> state,
-) -> Result(state, Nil)
+) {
+  base(a, b, c, True)
+}

--- a/src/htmgrrrl_ffi.erl
+++ b/src/htmgrrrl_ffi.erl
@@ -1,12 +1,12 @@
 -module(htmgrrrl_ffi).
 
--export([sax/4]).
+-export([sax/3]).
 
-sax(Html, Initial, Fun, PreserveWs) ->
+sax(Html, Initial, Fun) ->
     EventFun = fun(Event, LineNumber, State) ->
         Fun(State, LineNumber, convert_event(Event))
     end,
-    case htmerl:sax(Html, [{event_fun, EventFun}, {user_state, Initial}, {preserve_ws, PreserveWs}]) of
+    case htmerl:sax(Html, [{event_fun, EventFun}, {user_state, Initial}, {preserve_ws, true}]) of
         {ok, State, _Warnings} ->
             {ok, State};
         _ ->

--- a/src/htmgrrrl_ffi.erl
+++ b/src/htmgrrrl_ffi.erl
@@ -1,12 +1,12 @@
 -module(htmgrrrl_ffi).
 
--export([sax/3]).
+-export([sax/4]).
 
-sax(Html, Initial, Fun) ->
+sax(Html, Initial, Fun, PreserveWs) ->
     EventFun = fun(Event, LineNumber, State) ->
         Fun(State, LineNumber, convert_event(Event))
     end,
-    case htmerl:sax(Html, [{event_fun, EventFun}, {user_state, Initial}]) of
+    case htmerl:sax(Html, [{event_fun, EventFun}, {user_state, Initial}, {preserve_ws, PreserveWs}]) of
         {ok, State, _Warnings} ->
             {ok, State};
         _ ->

--- a/test/htmgrrrl_test.gleam
+++ b/test/htmgrrrl_test.gleam
@@ -60,3 +60,19 @@ pub fn example_test() {
   assert htmgrrrl.sax("<p>Hello, Joe!</p><p>Hello, Mike!</p>", [], take_text)
     == Ok(["Hello, Mike!", "Hello, Joe!"])
 }
+
+pub fn example_preserve_ws_test() {
+  let take_text = fn(state, _line, event) {
+    case event {
+      Characters(text) -> [text, ..state]
+      _ -> state
+    }
+  }
+
+  assert htmgrrrl.sax_preserve_ws(
+      "<p>Hello, Joe!</p><p>\nHello, Mike!  </p>",
+      [],
+      take_text,
+    )
+    == Ok(["\nHello, Mike!  ", "Hello, Joe!"])
+}

--- a/test/htmgrrrl_test.gleam
+++ b/test/htmgrrrl_test.gleam
@@ -61,7 +61,7 @@ pub fn example_test() {
     == Ok(["Hello, Mike!", "Hello, Joe!"])
 }
 
-pub fn example_preserve_ws_test() {
+pub fn example_with_whitespace_test() {
   let take_text = fn(state, _line, event) {
     case event {
       Characters(text) -> [text, ..state]
@@ -69,7 +69,7 @@ pub fn example_preserve_ws_test() {
     }
   }
 
-  assert htmgrrrl.sax_preserve_ws(
+  assert htmgrrrl.sax(
       "<p>Hello, Joe!</p><p>\nHello, Mike!  </p>",
       [],
       take_text,


### PR DESCRIPTION
I ran into issues parsing HTML with `script` tags in it since these tags end up having their whitespace collapsed which can lead to content

This PR exposes the option that was added here: https://github.com/zadean/htmerl/issues/7

Let me know if you'd like any changes to how the method is exposed or how the options should work